### PR TITLE
test: delete members with atomic_operation

### DIFF
--- a/rln/rln.go
+++ b/rln/rln.go
@@ -3,6 +3,7 @@ package rln
 import "C"
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -282,7 +283,17 @@ func (r *RLN) InsertMember(idComm IDCommitment) error {
 func (r *RLN) InsertMembers(index MembershipIndex, idComms []IDCommitment) error {
 	idCommBytes := serializeCommitments(idComms)
 	indicesBytes := serializeIndices(nil)
+
+	fmt.Println("--------------")
+	fmt.Println("Sending the following values to atomic_operation:")
+	fmt.Println("* START: ", index)
+	fmt.Println("* LEAVES: ", hex.EncodeToString(idCommBytes))
+	fmt.Println("* INDICES: ", hex.EncodeToString(indicesBytes))
+
 	insertionSuccess := r.w.AtomicOperation(index, idCommBytes, indicesBytes)
+	fmt.Println("\n* EXECUTION RESULT SUCCESSFUL: ", insertionSuccess)
+	fmt.Println("--------------")
+
 	if !insertionSuccess {
 		return errors.New("could not insert members")
 	}
@@ -304,9 +315,19 @@ func (r *RLN) DeleteMember(index MembershipIndex) error {
 func (r *RLN) DeleteMembers(indices []MembershipIndex) error {
 	idCommBytes := serializeCommitments(nil)
 	indicesBytes := serializeIndices(indices)
-	insertionSuccess := r.w.AtomicOperation(0, idCommBytes, indicesBytes)
-	if !insertionSuccess {
-		return errors.New("could not insert members")
+
+	fmt.Println("--------------")
+	fmt.Println("Sending the following values to atomic_operation:")
+	fmt.Println("* START: ", 0)
+	fmt.Println("* LEAVES: ", hex.EncodeToString(idCommBytes))
+	fmt.Println("* INDICES: ", hex.EncodeToString(indicesBytes))
+
+	deleteSuccess := r.w.AtomicOperation(0, idCommBytes, indicesBytes)
+	fmt.Println("\n* EXECUTION RESULT SUCCESSFUL: ", deleteSuccess)
+	fmt.Println("--------------")
+
+	if !deleteSuccess {
+		return errors.New("could not delete members")
 	}
 	return nil
 }

--- a/rln/rln_test.go
+++ b/rln/rln_test.go
@@ -300,3 +300,24 @@ func (s *RLNSuite) TestEpochComparison() {
 	s.Equal(int64(1), Diff(epoch1, epoch2))
 	s.Equal(int64(-1), Diff(epoch2, epoch1))
 }
+
+func (s *RLNSuite) TestDeleteMembersWithAtomicWrite() {
+	rln, err := NewRLN()
+	s.NoError(err)
+
+	var commitments []IDCommitment
+
+	// Create a Merkle tree with random members
+	for i := 0; i < 3; i++ {
+		// create a new key pair
+		memberKeys, err := rln.MembershipKeyGen()
+		s.NoError(err)
+		commitments = append(commitments, memberKeys.IDCommitment)
+	}
+
+	err = rln.InsertMembers(0, commitments) // If inserting members from scratch, should the index be 0 or 1?
+	s.NoError(err)
+
+	err = rln.DeleteMembers([]uint{2}) // This should delete index 2, but fails
+	s.NoError(err)
+}


### PR DESCRIPTION
To see the failing scenario, clone the repo, and execute the following:
```
go test -timeout 300s -run TestRLNSuite/TestDeleteMembersWithAtomicWrite github.com/waku-org/go-zerokit-rln/rl
```

You should see an output similar to this:
```
--------------
Sending the following values to atomic_operation:
* START:  0
* LEAVES:  03000000000000005b0400d46908979eceed30d2d4d32ee92878a9bed0ec9512460eb55bc41c0f2272894185661ba7102c6ef6e761f7ba3373c0e81495799c13687ae5c064a9bc23ed15b97617f3353d24fde862b8155a1be0e73afc05b013ddd87781962b333c21
* INDICES:  0000000000000000

* EXECUTION RESULT SUCCESSFUL:  true
--------------
--------------
Sending the following values to atomic_operation:
* START:  0
* LEAVES:  0000000000000000
* INDICES:  01000000000000000200000000000000

* EXECUTION RESULT SUCCESSFUL:  false
--------------
--- FAIL: TestRLNSuite (3.50s)
    --- FAIL: TestRLNSuite/TestDeleteMembersWithAtomicWrite (3.50s)
        rln_test.go:322: 
                Error Trace:    rln_test.go:322
                Error:          Received unexpected error:
                                could not delete members
                Test:           TestRLNSuite/TestDeleteMembersWithAtomicWrite
FAIL
FAIL    github.com/waku-org/go-zerokit-rln/rln  3.515s
FAIL
```