### PR TITLE
Add InsertRawLeaf

### DIFF
--- a/rln/rln.go
+++ b/rln/rln.go
@@ -427,6 +427,14 @@ func (r *RLN) InsertMember(idComm IDCommitment, userMessageLimit uint32) error {
 	return nil
 }
 
+func (r *RLN) InsertRawLeaf(rawLeaf [32]byte) error {
+	insertionSuccess := r.w.SetNextLeaf(rawLeaf[:])
+	if !insertionSuccess {
+		return errors.New("could not insert raw leaf")
+	}
+	return nil
+}
+
 // Insert multiple members i.e., identity commitments starting from index
 // This proc is atomic, i.e., if any of the insertions fails, all the previous insertions are rolled back
 func (r *RLN) InsertMembers(index MembershipIndex, idComms []IDCommitment) error {

--- a/rln/rln.go
+++ b/rln/rln.go
@@ -427,7 +427,7 @@ func (r *RLN) InsertMember(idComm IDCommitment, userMessageLimit uint32) error {
 	return nil
 }
 
-func (r *RLN) InsertRawLeaf(rawLeaf [32]byte) error {
+func (r *RLN) InsertRawLeaf(rawLeaf MerkleNode) error {
 	insertionSuccess := r.w.SetNextLeaf(rawLeaf[:])
 	if !insertionSuccess {
 		return errors.New("could not insert raw leaf")

--- a/rln/rln_test.go
+++ b/rln/rln_test.go
@@ -80,6 +80,37 @@ func (s *RLNSuite) TestInsertMember() {
 	s.NoError(err)
 }
 
+func (s *RLNSuite) TestInsertRawLeaf() {
+	rln, err := NewRLN()
+	s.NoError(err)
+
+	for i := 0; i < 10; i++ {
+		// Generate a membership
+		memKeys, err := rln.MembershipKeyGen(10)
+		s.NoError(err)
+
+		// Calculate the leaf ourselves
+		userMessageLimitBytes := SerializeUint32(memKeys.UserMessageLimit)
+		hashedLeaf, err := rln.Poseidon(memKeys.IDCommitment[:], userMessageLimitBytes[:])
+		s.NoError(err)
+
+		// Insert the leaf as it is
+		err = rln.InsertRawLeaf(hashedLeaf)
+		s.NoError(err)
+
+		// Get it from the tree
+		retrievedLeaf, err := rln.GetLeaf(uint(i))
+		s.NoError(err)
+
+		// Check the retrieved matches the one we added
+		s.Equal(hashedLeaf, retrievedLeaf)
+
+		// Check tree size matches
+		numLeaves := rln.LeavesSet()
+		s.Equal(uint(i+1), numLeaves)
+	}
+}
+
 func (s *RLNSuite) TestInsertMembers() {
 	rln, err := NewRLN()
 	s.NoError(err)


### PR DESCRIPTION
* Add `InsertRawLeaf` that allows to insert a raw leaf.
* This is needed since the existing `InsertMember(idComm, userMessageLimit)` inserts the `poseidon(idComm, userMessageLimit)` but one might already know that hash.
* This PR allows to insert that hash if known beforehand.